### PR TITLE
Fix workflow permission for build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install GCC and 32-bit libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc g++ gcc-multilib g++-multilib
+      - name: Make build script executable
+        run: chmod +x build.sh
+      - name: Run build script
+        run: ./build.sh
+        shell: bash


### PR DESCRIPTION
## Summary
- ensure the CI job can execute `build.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841dc6c2e308321830b383473c0ef8c